### PR TITLE
Clean up Playwright page objects after merge

### DIFF
--- a/tests/pages/basePage.ts
+++ b/tests/pages/basePage.ts
@@ -9,41 +9,44 @@ export default class BasePage {
     this.page = page;
   }
  
-  
-  async b_navigateTo(url: string, timeout: number = maxTimeout) {
+  async b_navigateTo(url: string, timeout: number = maxTimeout): Promise<void> {
     await this.page.goto(url, { timeout, waitUntil: 'networkidle' });
   }
 
-  async b_waitForElementVisible(locator: Locator, timeout: number = maxTimeout) {
+  async b_waitForElementVisible(locator: Locator, timeout: number = maxTimeout): Promise<void> {
     await locator.waitFor({ state: 'visible', timeout });
   }
 
-  async b_fillField(element: Locator, text: string, isForceFill: boolean = false, timeout: number = maxTimeout) {
+  async b_fillField(element: Locator, text: string, timeout: number = maxTimeout): Promise<void> {
     await this.b_waitForElementVisible(element, timeout);
-    await element.pressSequentially(text, { timeout });
+    try {
+      await element.fill(text, { timeout });
+    } catch {
+      await element.pressSequentially(text, { timeout });
+    }
   }
 
-  async b_clickElement(element: Locator, timeout: number = maxTimeout) {
+  async b_clickElement(element: Locator, timeout: number = maxTimeout): Promise<void> {
     await this.b_waitForElementVisible(element, timeout);
     await element.click({ timeout });
   }
 
-  async b_clearField(locator: Locator) {
+  async b_clearField(locator: Locator): Promise<void> {
     await this.b_waitForElementVisible(locator);
     await locator.fill('');
   }
 
-  async b_textvisible(locator: Locator, expected: string) {
+  async b_textvisible(locator: Locator, expected: string): Promise<void> {
     await expect(locator).toHaveText(expected, { timeout: maxTimeout });
   }
 
-    async b_getElementCount(element: Locator, maxTimeout?: number): Promise<number> {
-    await this.b_waitForElementVisible(element, maxTimeout);
+  async b_getElementCount(element: Locator, timeout: number = maxTimeout): Promise<number> {
+    await this.b_waitForElementVisible(element, timeout);
     return await element.count();
   }
 
   async b_waitForPageToLoad(): Promise<void> {
-    await this.page.waitForLoadState("networkidle");
+    await this.page.waitForLoadState('networkidle');
     await this.page.waitForTimeout(1000);
   }
 

--- a/tests/pages/composeMessage.ts
+++ b/tests/pages/composeMessage.ts
@@ -1,6 +1,6 @@
 import { Page, Locator } from '@playwright/test';
-import BasePage from './basePage.js'
-import type { Row } from './readRecruiterNames.ts';
+import BasePage from './basePage';
+import type { Row } from './readRecruiterNames';
 
 function sydneyWeekday(dayOffset = 0): string {
   const now = new Date();
@@ -37,7 +37,7 @@ export function buildMessage(r: Row, dayOffset = 0): string {
     '',
     'A new beginning awaits me.',
     'I want to thank you for your support during my unemployment.',
-    `You\'ve been awesome ${smile}. Let\'s keep in touch.`,
+    `You've been awesome ${smile}. Let's keep in touch.`,
     'Have a great week.',
     'Best regards,',
     'Sameer'
@@ -53,8 +53,8 @@ export class ComposeMessagePage extends BasePage {
     super(page);
     this.messageButton = page.getByRole('button', { name: /message/i });
     this.messageBox = page.getByRole('textbox');
-    this.sendButton = page.locator("button[type='submit']"); 
-    this.closeMessageBox = page.getByRole('button', { name: /^Close your conversation with/i})
+    this.sendButton = page.locator("button[type='submit']");
+    this.closeMessageBox = page.getByRole('button', { name: /^Close your conversation with/i });
   }
 
   async openMessage(): Promise<void> {
@@ -76,13 +76,13 @@ export class ComposeMessagePage extends BasePage {
     return text;
   }
 
-  async sendMessage() {
+  async sendMessage(): Promise<void> {
     await this.b_clickElement(this.sendButton);
   }
 
-async closeMessage(){
-  await this.b_clickElement(this.closeMessageBox)
-}
+  async closeMessage(): Promise<void> {
+    await this.b_clickElement(this.closeMessageBox);
+  }
 }
 
 export default ComposeMessagePage;

--- a/tests/pages/linkedInSearchPage.ts
+++ b/tests/pages/linkedInSearchPage.ts
@@ -1,9 +1,6 @@
 import { Page, Locator, expect } from '@playwright/test';
 import BasePage from './basePage';
 
-// Calling Recruiter name list from the recruiter data file 
-
-
 export class LinkedInSearchPage extends BasePage {
   private readonly searchBox: Locator;
   private readonly resultsListItems: Locator;
@@ -16,20 +13,16 @@ export class LinkedInSearchPage extends BasePage {
     this.firstResultLink = this.resultsListItems.first().locator('a[href*="/in/"]');
   }
 
-// Naviagte to LinkedIn feed where global search is visible 
-
-async gotoFeed() {
-  await this.page.goto('https://www.linkedin.com/feed/', {waitUntil: 'domcontentloaded'});
-  await expect(this.searchBox).toBeVisible({timeout:15000}); 
-}
-
-// Search for recruiter names  
-async searchForRecruiterNames(recruiterName: string) { 
-    await this.searchBox.click();
-    await this.searchBox.fill(recruiterName);
-    await this.searchBox.press('Enter'); 
+  async gotoFeed(): Promise<void> {
+    await this.page.goto('https://www.linkedin.com/feed/', { waitUntil: 'domcontentloaded' });
+    await expect(this.searchBox).toBeVisible({ timeout: 15_000 });
   }
 
-}; 
-
-// 
+  async searchForRecruiterNames(recruiterName: string): Promise<void> {
+    await this.searchBox.click();
+    await this.searchBox.fill(recruiterName);
+    await this.searchBox.press('Enter');
+    await expect(this.resultsListItems.first()).toBeVisible({ timeout: 15_000 });
+    await expect(this.firstResultLink).toBeVisible({ timeout: 15_000 });
+  }
+}

--- a/tests/pages/loginPage.ts
+++ b/tests/pages/loginPage.ts
@@ -1,4 +1,4 @@
-import { Page, Locator, expect } from '@playwright/test';
+import { Page, Locator } from '@playwright/test';
 import BasePage from './basePage';
 
 export class LoginPage extends BasePage {
@@ -27,16 +27,16 @@ export class LoginPage extends BasePage {
     await this.b_clickElement(this.loginButton);
   }
 
-  async LinkedinLogo(logo: string) {
+  async LinkedinLogo(): Promise<void> {
     await this.b_waitForElementVisible(this.linkedinLogo);
   }
 
   // Combined login method
-  async login(username: string, password: string) {
+  async login(username: string, password: string): Promise<void> {
     await this.enterUserName(username);
     await this.enterPassword(password);
     await this.clickLoginButton();
-    await this.LinkedinLogo('');
+    await this.LinkedinLogo();
   }
-  }; 
+}
 

--- a/tests/pages/logoutPage.ts
+++ b/tests/pages/logoutPage.ts
@@ -1,23 +1,23 @@
-import BasePage from "./basePage";
-import { Page, Locator,expect } from "playwright/test";
+import BasePage from './basePage';
+import { Page, Locator } from '@playwright/test';
 
 export class LogoutPage extends BasePage {
-    private readonly navigationButton: Locator;
-    private readonly signOutButton: Locator;
+  private readonly navigationButton: Locator;
+  private readonly signOutButton: Locator;
 
-    constructor(page: Page) {
-        super(page);
-        this.navigationButton = page.locator('.global-nav__icon.global-nav__icon--small');
-        this.signOutButton = page.locator("//a[@class='global-nav__secondary-link mv1']");
-    }
+  constructor(page: Page) {
+    super(page);
+    this.navigationButton = page.locator('.global-nav__icon.global-nav__icon--small');
+    this.signOutButton = page.locator("//a[@class='global-nav__secondary-link mv1']");
+  }
 
-    async navigateButton() {
-        await this.b_clickElement(this.navigationButton);
-    }
+  async navigateButton(): Promise<void> {
+    await this.b_clickElement(this.navigationButton);
+  }
 
-    async clickSignOut() {
-        await this.b_clickElement(this.signOutButton);
-    }
+  async clickSignOut(): Promise<void> {
+    await this.b_clickElement(this.signOutButton);
+  }
 }
 
 

--- a/tests/verifyE2EuserFlow.spec.ts
+++ b/tests/verifyE2EuserFlow.spec.ts
@@ -1,4 +1,4 @@
-import { test} from '../hooks/hooks';
+import { test } from '../hooks/hooks';
 import { LoginPage } from './pages/loginPage';
 import { LinkedInSearchPage } from './pages/linkedInSearchPage';
 import { getRecruiterNames } from './pages/readRecruiterNames';
@@ -15,7 +15,7 @@ test('[T6] Verify user flow', async ({ page, browser }) => {
 
   await login.b_navigateTo(process.env.BASE_URL!);
   await login.login(process.env.LINKEDIN_USERNAME!, process.env.LINKEDIN_PASSWORD!);
-  await login.LinkedinLogo('');
+  await login.LinkedinLogo();
 
   // Read recruiter names from Excel and search each
   const names = await getRecruiterNames('data/recruiterList.xlsx');
@@ -27,7 +27,6 @@ test('[T6] Verify user flow', async ({ page, browser }) => {
     await messageBtn.click();
 
     await composeMessage.openMessage();
-    await page.pause();
     await composeMessage.fillMessageFromRow({ Name: name });
     await composeMessage.sendMessage();
     await composeMessage.closeMessage();


### PR DESCRIPTION
## Summary
- realign merged Playwright page objects by fixing incorrect imports and TypeScript signatures
- harden recruiter search and compose message flows with additional waits and cleaner helpers
- remove debugging pause from the end-to-end test to keep the automation self-running

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d57b0190b0832b83dd224097389d49